### PR TITLE
Add Windows pen record/replay example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The script relies on Windows Raw Pointer APIs to capture coalesced pen samples a
 - Python 3.8+ with `comtypes` installed (the optional `winrt` package is not required)
 - Administrator privileges are required for input injection
 
-Install dependencies:
+Install dependencies (the script can attempt to install them automatically when
+run as administrator):
 
 ```bash
 pip install comtypes
@@ -39,3 +40,10 @@ python record_pen.py --replay
 Running the script without any arguments launches a simple window with
 **Record** and **Replay** buttons. Press **Record** to capture a stroke and
 save it to `recording.json`, or **Replay** to inject the saved events back.
+
+### Administrator privileges
+
+Replaying pen events requires elevated rights. When started without
+administrator privileges, the script will prompt to relaunch itself with the
+necessary permissions. Missing packages such as `comtypes` will be installed at
+startup when running as administrator.

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 This repository provides a Python script `record_pen.py` for recording and replaying stylus (pen) input on Windows.
 
-The script relies on Windows Raw Pointer APIs to capture coalesced pen samples along with pressure values and stores them in `recording.json`. It can also replay the captured strokes using the Input Injection API via WinRT.
+The script relies on Windows Raw Pointer APIs to capture coalesced pen samples along with pressure values and stores them in `recording.json`. It replays those strokes using the Win32 synthetic pointer device API.
 
 ## Requirements
 
 - Windows 10 with the Windows 10 SDK installed
- - Python 3.8+ with `comtypes` and `winrt` packages installed
+- Python 3.8+ with `comtypes` installed (the optional `winrt` package is not required)
 - Administrator privileges are required for input injection
 
 Install dependencies:
 
 ```bash
-pip install comtypes winrt
+pip install comtypes
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,49 +1,44 @@
 # Record Pen
 
-This repository provides a Python script `record_pen.py` for recording and replaying stylus (pen) input on Windows.
+This repository provides two ways to record and replay stylus (pen) input on Windows.
 
-The script relies on Windows Raw Pointer APIs to capture coalesced pen samples along with pressure values and stores them in `recording.json`. It replays those strokes using the Win32 synthetic pointer device API.
+- `record_pen.py` – the original Python implementation using ctypes.
+- `RecordPen` – a C# WinForms application that offers the same recording and replay functionality.
 
-## Requirements
+Both approaches store the captured samples in `recording.json` and replay them preserving timing and pressure.
+
+## Python approach
+
+The Python script relies on Windows Raw Pointer APIs and requires:
 
 - Windows 10 with the Windows 10 SDK installed
-- Python 3.8+ with `comtypes` installed (the optional `winrt` package is not required)
-- Administrator privileges are required for input injection
+- Python 3.8+ with `comtypes` installed
+- Administrator privileges for input injection
 
-Install dependencies (the script can attempt to install them automatically when
-run as administrator):
+Install the dependency (the script can auto-install when run as administrator):
 
 ```bash
 pip install comtypes
 ```
 
-## Usage
-
-You can either run the script with command-line flags or use the built-in GUI.
-
-### Command line
-
-Record pen input:
+Run the GUI or record from the command line:
 
 ```bash
-python record_pen.py --record
+python record_pen.py --record   # capture strokes
+python record_pen.py --replay   # replay them
 ```
 
-Replay the recorded input:
+Running without arguments launches a Tkinter window with **Record** and **Replay** buttons.
+
+## C# WinForms approach
+
+If the Python version does not work on your system, you can build the C# project instead. Install the .NET SDK 8.0 or newer, then run:
 
 ```bash
-python record_pen.py --replay
+cd RecordPen
+ dotnet build -c Release
 ```
 
-### GUI
+This produces `RecordPen.exe` in `bin/Release/net8.0-windows`. Run it to get a window with **Record** and **Replay** buttons. The application listens for pen input when **Record** is pressed and writes the data to `recording.json`. Selecting **Replay** injects the stored strokes back.
 
-Running the script without any arguments launches a simple window with
-**Record** and **Replay** buttons. Press **Record** to capture a stroke and
-save it to `recording.json`, or **Replay** to inject the saved events back.
-
-### Administrator privileges
-
-Replaying pen events requires elevated rights. When started without
-administrator privileges, the script will prompt to relaunch itself with the
-necessary permissions. Missing packages such as `comtypes` will be installed at
-startup when running as administrator.
+Administrator rights are still required for replaying input.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# record-pen
+# Record Pen
+
+This repository provides a Python script `record_pen.py` for recording and replaying stylus (pen) input on Windows.
+
+The script relies on Windows Raw Pointer APIs to capture coalesced pen samples along with pressure values and stores them in `recording.json`. It can also replay the captured strokes using the Input Injection API via WinRT.
+
+## Requirements
+
+- Windows 10 with the Windows 10 SDK installed
+- Python 3.8+ with `comtypes` and `pywinrt` packages installed
+- Administrator privileges are required for input injection
+
+Install dependencies:
+
+```bash
+pip install comtypes pywinrt
+```
+
+## Usage
+
+To record pen input:
+
+```bash
+python record_pen.py --record
+```
+
+Press the pen on the screen to draw. The samples will be saved to `recording.json` when the pen is lifted.
+
+To replay the recorded input:
+
+```bash
+python record_pen.py --replay
+```
+
+The replay uses the timestamps stored in the JSON file to reproduce the drawing speed.

--- a/README.md
+++ b/README.md
@@ -7,29 +7,35 @@ The script relies on Windows Raw Pointer APIs to capture coalesced pen samples a
 ## Requirements
 
 - Windows 10 with the Windows 10 SDK installed
-- Python 3.8+ with `comtypes` and `pywinrt` packages installed
+ - Python 3.8+ with `comtypes` and `winrt` packages installed
 - Administrator privileges are required for input injection
 
 Install dependencies:
 
 ```bash
-pip install comtypes pywinrt
+pip install comtypes winrt
 ```
 
 ## Usage
 
-To record pen input:
+You can either run the script with command-line flags or use the built-in GUI.
+
+### Command line
+
+Record pen input:
 
 ```bash
 python record_pen.py --record
 ```
 
-Press the pen on the screen to draw. The samples will be saved to `recording.json` when the pen is lifted.
-
-To replay the recorded input:
+Replay the recorded input:
 
 ```bash
 python record_pen.py --replay
 ```
 
-The replay uses the timestamps stored in the JSON file to reproduce the drawing speed.
+### GUI
+
+Running the script without any arguments launches a simple window with
+**Record** and **Replay** buttons. Press **Record** to capture a stroke and
+save it to `recording.json`, or **Replay** to inject the saved events back.

--- a/RecordPen/Program.cs
+++ b/RecordPen/Program.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Windows.Forms;
+using Windows.UI.Input.Preview.Injection;
+
+namespace RecordPen
+{
+    public partial class MainForm : Form
+    {
+        private const int WM_POINTERDOWN = 0x0246;
+        private const int WM_POINTERUPDATE = 0x0247;
+        private const int WM_POINTERUP = 0x0248;
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct POINT { public int x; public int y; }
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct POINTER_INFO
+        {
+            public uint pointerType;
+            public uint pointerId;
+            public uint frameId;
+            public uint pointerFlags;
+            public IntPtr sourceDevice;
+            public IntPtr hwndTarget;
+            public POINT ptPixelLocation;
+            public POINT ptHimetricLocation;
+            public POINT ptPixelLocationRaw;
+            public POINT ptHimetricLocationRaw;
+            public uint dwTime;
+            public uint historyCount;
+            public int inputData;
+            public uint dwKeyStates;
+            public ulong PerformanceCount;
+            public uint ButtonChangeType;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct POINTER_PEN_INFO
+        {
+            public POINTER_INFO pointerInfo;
+            public uint penFlags;
+            public uint penMask;
+            public uint pressure;
+            public uint rotation;
+            public int tiltX;
+            public int tiltY;
+        }
+
+        [DllImport("user32.dll")]
+        static extern bool GetPointerFramePenInfoHistory(uint pointerId, IntPtr entriesCount, ref uint count, [Out] POINTER_PEN_INFO[] penInfo);
+
+        private List<PenEvent> events = new();
+        private bool recording = false;
+
+        public MainForm()
+        {
+            Text = "Record Pen";
+            Width = 200;
+            Height = 120;
+
+            var recordButton = new Button { Text = "Record", Dock = DockStyle.Top };
+            var replayButton = new Button { Text = "Replay", Dock = DockStyle.Top };
+            var statusLabel = new Label { Text = "Idle", Dock = DockStyle.Top };
+
+            recordButton.Click += (s, e) =>
+            {
+                events.Clear();
+                recording = true;
+                statusLabel.Text = "Recording...";
+            };
+
+            replayButton.Click += async (s, e) =>
+            {
+                statusLabel.Text = "Replaying...";
+                await System.Threading.Tasks.Task.Run(() => Replay());
+                statusLabel.Text = "Idle";
+            };
+
+            Controls.Add(replayButton);
+            Controls.Add(recordButton);
+            Controls.Add(statusLabel);
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            base.WndProc(ref m);
+            if (!recording) return;
+            if (m.Msg == WM_POINTERDOWN || m.Msg == WM_POINTERUPDATE || m.Msg == WM_POINTERUP)
+            {
+                uint pointerId = (uint)m.WParam.ToInt32() & 0xFFFF;
+                uint count = 0;
+                GetPointerFramePenInfoHistory(pointerId, IntPtr.Zero, ref count, null);
+                if (count > 0)
+                {
+                    var arr = new POINTER_PEN_INFO[count];
+                    GetPointerFramePenInfoHistory(pointerId, IntPtr.Zero, ref count, arr);
+                    string type = m.Msg switch
+                    {
+                        WM_POINTERDOWN => "down",
+                        WM_POINTERUP => "up",
+                        _ => "move"
+                    };
+                    foreach (var info in arr)
+                    {
+                        events.Add(new PenEvent
+                        {
+                            Type = type,
+                            X = info.pointerInfo.ptPixelLocation.x,
+                            Y = info.pointerInfo.ptPixelLocation.y,
+                            Pressure = info.pressure,
+                            Timestamp = Stopwatch.GetTimestamp() / (double)Stopwatch.Frequency
+                        });
+                    }
+                    if (m.Msg == WM_POINTERUP)
+                    {
+                        File.WriteAllText("recording.json", JsonSerializer.Serialize(events, new JsonSerializerOptions { WriteIndented = true }));
+                        recording = false;
+                    }
+                }
+            }
+        }
+
+        private void Replay()
+        {
+            if (!File.Exists("recording.json")) return;
+            var data = JsonSerializer.Deserialize<List<PenEvent>>(File.ReadAllText("recording.json"));
+            if (data == null || data.Count == 0) return;
+
+            var injector = InputInjector.TryCreate();
+            var device = injector.InitializePenInjection();
+            double prev = data[0].Timestamp;
+            foreach (var ev in data)
+            {
+                System.Threading.Thread.Sleep(TimeSpan.FromSeconds(ev.Timestamp - prev));
+                prev = ev.Timestamp;
+                var info = new InjectedInputPenInfo
+                {
+                    PointerInfo = new InjectedInputPointerInfo
+                    {
+                        PointerOptions = ev.Type == "down" ? InjectedInputPointerOptions.InRange | InjectedInputPointerOptions.InContact | InjectedInputPointerOptions.Primary | InjectedInputPointerOptions.PenDown
+                            : ev.Type == "up" ? InjectedInputPointerOptions.PointerUp
+                            : InjectedInputPointerOptions.InRange | InjectedInputPointerOptions.InContact,
+                        PixelLocation = new Windows.Foundation.Point(ev.X, ev.Y)
+                    },
+                    Pressure = (ushort)Math.Min(Math.Max(ev.Pressure, 0), 1024)
+                };
+                injector.InjectPenInput(new[] { info });
+            }
+        }
+    }
+
+    class PenEvent
+    {
+        public string Type { get; set; } = "";
+        public int X { get; set; }
+        public int Y { get; set; }
+        public uint Pressure { get; set; }
+        public double Timestamp { get; set; }
+    }
+
+    internal static class Program
+    {
+        [STAThread]
+        static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new MainForm());
+        }
+    }
+}

--- a/RecordPen/RecordPen.csproj
+++ b/RecordPen/RecordPen.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.NET" Version="10.0.22621.1" />
+  </ItemGroup>
+</Project>

--- a/record_pen.py
+++ b/record_pen.py
@@ -1,4 +1,10 @@
-"""Record and replay pen input on Windows using Raw Pointer and Input Injection APIs."""
+"""Record and replay pen input on Windows.
+
+The script records WM_POINTER messages with pressure data using the Raw Pointer
+API and replays them with the Win32 synthetic pointer device APIs. It only
+depends on ``ctypes`` and ``comtypes``; the optional ``winrt`` package is not
+required.
+"""
 
 import ctypes
 import json
@@ -13,15 +19,11 @@ try:
 except ImportError:
     comtypes = None
 
+# The WinRT package `winrt` is not required. Set InputInjector to None to
+# indicate that the optional dependency is unavailable.
 try:
-    from winrt.windows.ui.input.preview.injection import (
-        InputInjector,
-        InjectedInputPenInfo,
-        InjectedInputPointerInfo,
-        InjectedInputPointerOptions,
-        InjectedInputPenButtons,
-    )
-except ImportError:
+    from winrt.windows.ui.input.preview.injection import InputInjector  # type: ignore
+except Exception:
     InputInjector = None
 
 user32 = ctypes.WinDLL("user32", use_last_error=True)
@@ -30,6 +32,20 @@ user32 = ctypes.WinDLL("user32", use_last_error=True)
 WM_POINTERDOWN = 0x0246
 WM_POINTERUPDATE = 0x0247
 WM_POINTERUP = 0x0248
+
+# Pointer device constants
+PT_PEN = 0x00000003
+
+# Feedback mode
+POINTER_FEEDBACK_DEFAULT = 1
+
+# Basic pointer flags
+POINTER_FLAG_NONE = 0x00000000
+POINTER_FLAG_INRANGE = 0x00000002
+POINTER_FLAG_INCONTACT = 0x00000004
+POINTER_FLAG_DOWN = 0x00010000
+POINTER_FLAG_UPDATE = 0x00020000
+POINTER_FLAG_UP = 0x00040000
 
 # Structures from Win32 API
 class POINT(ctypes.Structure):
@@ -69,6 +85,19 @@ class POINTER_PEN_INFO(ctypes.Structure):
         ("tiltY", wintypes.INT32),
     ]
 
+
+class _POINTER_TYPE_INFO_UNION(ctypes.Union):
+    _fields_ = [
+        ("penInfo", POINTER_PEN_INFO),
+    ]
+
+
+class POINTER_TYPE_INFO(ctypes.Structure):
+    _fields_ = [
+        ("type", wintypes.DWORD),
+        ("DUMMYUNIONNAME", _POINTER_TYPE_INFO_UNION),
+    ]
+
 # Function prototypes
 GetPointerFramePenInfoHistory = user32.GetPointerFramePenInfoHistory
 GetPointerFramePenInfoHistory.restype = wintypes.BOOL
@@ -83,9 +112,22 @@ InjectSyntheticPointerInput = user32.InjectSyntheticPointerInput
 InjectSyntheticPointerInput.restype = wintypes.BOOL
 InjectSyntheticPointerInput.argtypes = [
     wintypes.HANDLE,
-    ctypes.POINTER(POINTER_PEN_INFO),
+    ctypes.POINTER(POINTER_TYPE_INFO),
     wintypes.UINT32,
 ]
+
+# Additional Win32 APIs for injecting pointers without WinRT
+CreateSyntheticPointerDevice = user32.CreateSyntheticPointerDevice
+CreateSyntheticPointerDevice.restype = wintypes.HANDLE
+CreateSyntheticPointerDevice.argtypes = [
+    wintypes.DWORD,  # POINTER_INPUT_TYPE
+    wintypes.ULONG,
+    wintypes.DWORD,  # POINTER_FEEDBACK_MODE
+]
+
+DestroySyntheticPointerDevice = user32.DestroySyntheticPointerDevice
+DestroySyntheticPointerDevice.restype = None
+DestroySyntheticPointerDevice.argtypes = [wintypes.HANDLE]
 
 # Message window setup
 WNDPROC = ctypes.WINFUNCTYPE(wintypes.LRESULT, wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM)
@@ -94,26 +136,35 @@ records = []
 
 @WNDPROC
 def wnd_proc(hwnd, msg, wparam, lparam):
-    if msg == WM_POINTERUPDATE:
+    if msg in (WM_POINTERDOWN, WM_POINTERUPDATE, WM_POINTERUP):
         pointer_id = wparam & 0xFFFF
         count = ctypes.c_uint32()
+        # Query how many coalesced samples are available
         GetPointerFramePenInfoHistory(pointer_id, None, ctypes.byref(count), None)
         arr_type = POINTER_PEN_INFO * count.value
         infos = arr_type()
         GetPointerFramePenInfoHistory(pointer_id, None, ctypes.byref(count), infos)
+        evt_type = {
+            WM_POINTERDOWN: "down",
+            WM_POINTERUPDATE: "move",
+            WM_POINTERUP: "up",
+        }[msg]
         for info in infos:
             pt = info.pointerInfo.ptPixelLocation
-            records.append({
-                "x": pt.x,
-                "y": pt.y,
-                "pressure": info.pressure,
-                "t": time.time(),
-            })
-    elif msg == WM_POINTERUP:
-        with open("recording.json", "w", encoding="utf-8") as f:
-            json.dump(records, f, indent=2)
-        print("Recording saved to recording.json")
-        user32.PostQuitMessage(0)
+            records.append(
+                {
+                    "type": evt_type,
+                    "x": pt.x,
+                    "y": pt.y,
+                    "pressure": info.pressure,
+                    "t": time.time(),
+                }
+            )
+        if msg == WM_POINTERUP:
+            with open("recording.json", "w", encoding="utf-8") as f:
+                json.dump(records, f, indent=2)
+            print("Recording saved to recording.json")
+            user32.PostQuitMessage(0)
     return user32.DefWindowProcW(hwnd, msg, wparam, lparam)
 
 WNDCLASS = ctypes.Structure
@@ -178,27 +229,45 @@ def record():
 
 
 def replay():
-    if InputInjector is None:
-        print("WinRT input injection APIs not available")
-        return
+    """Replay events stored in recording.json using synthetic pointer APIs."""
     with open("recording.json", "r", encoding="utf-8") as f:
         events = json.load(f)
-    injector = InputInjector.try_create()
-    if injector is None:
-        print("Failed to create InputInjector")
+
+    device = CreateSyntheticPointerDevice(PT_PEN, 1, POINTER_FEEDBACK_DEFAULT)
+    if not device:
+        print("Failed to create synthetic pen device")
         return
-    prev_t = None
-    for ev in events:
-        if prev_t is not None:
-            time.sleep(max(ev["t"] - prev_t, 0))
-        prev_t = ev["t"]
-        pen = InjectedInputPenInfo()
-        info = InjectedInputPointerInfo()
-        info.pointer_options = InjectedInputPointerOptions.IN_CONTACT | InjectedInputPointerOptions.PEN
-        info.pixel_location = POINT(ev["x"], ev["y"])
-        pen.pointer_info = info
-        pen.pressure = int(ev["pressure"])
-        injector.inject_pen_input([pen])
+
+    try:
+        prev_t = None
+        for ev in events:
+            if prev_t is not None:
+                time.sleep(max(ev["t"] - prev_t, 0))
+            prev_t = ev["t"]
+
+            pointer = POINTER_TYPE_INFO()
+            pointer.type = PT_PEN
+            pen = pointer.DUMMYUNIONNAME.penInfo
+            pen.pointerInfo.pointerType = PT_PEN
+            pen.pointerInfo.pointerId = 0
+            if ev["type"] == "down":
+                pen.pointerInfo.pointerFlags = (
+                    POINTER_FLAG_DOWN | POINTER_FLAG_INRANGE | POINTER_FLAG_INCONTACT
+                )
+            elif ev["type"] == "up":
+                pen.pointerInfo.pointerFlags = POINTER_FLAG_UP
+            else:
+                pen.pointerInfo.pointerFlags = (
+                    POINTER_FLAG_UPDATE | POINTER_FLAG_INRANGE | POINTER_FLAG_INCONTACT
+                )
+            pen.pointerInfo.ptPixelLocation = POINT(int(ev["x"]), int(ev["y"]))
+            pen.penFlags = 0
+            pen.penMask = 1  # PEN_MASK_PRESSURE
+            pen.pressure = int(ev["pressure"])
+
+            InjectSyntheticPointerInput(device, ctypes.byref(pointer), 1)
+    finally:
+        DestroySyntheticPointerDevice(device)
 
 
 def main():

--- a/record_pen.py
+++ b/record_pen.py
@@ -4,6 +4,8 @@ import ctypes
 import json
 import sys
 import time
+import threading
+import tkinter as tk
 from ctypes import wintypes
 
 try:
@@ -111,6 +113,7 @@ def wnd_proc(hwnd, msg, wparam, lparam):
         with open("recording.json", "w", encoding="utf-8") as f:
             json.dump(records, f, indent=2)
         print("Recording saved to recording.json")
+        user32.PostQuitMessage(0)
     return user32.DefWindowProcW(hwnd, msg, wparam, lparam)
 
 WNDCLASS = ctypes.Structure
@@ -163,6 +166,17 @@ def message_loop():
         user32.DispatchMessageW(ctypes.byref(msg))
 
 
+def record():
+    """Run the pointer message loop and save events to recording.json."""
+    records.clear()
+    create_message_window()
+    message_loop()
+    if hwnd:
+        user32.DestroyWindow(hwnd)
+    if atom:
+        user32.UnregisterClassW(atom, user32.GetModuleHandleW(None))
+
+
 def replay():
     if InputInjector is None:
         print("WinRT input injection APIs not available")
@@ -190,13 +204,32 @@ def replay():
 def main():
     if comtypes:
         comtypes.CoInitialize()
+
+    def run_gui():
+        root = tk.Tk()
+        root.title("Pen Recorder")
+        status = tk.StringVar(value="Idle")
+
+        def start_record():
+            status.set("Recording...")
+            threading.Thread(target=lambda: (record(), status.set("Idle")), daemon=True).start()
+
+        def start_replay():
+            status.set("Replaying...")
+            threading.Thread(target=lambda: (replay(), status.set("Idle")), daemon=True).start()
+
+        tk.Button(root, text="Record", command=start_record).pack(fill="x")
+        tk.Button(root, text="Replay", command=start_replay).pack(fill="x")
+        tk.Label(root, textvariable=status).pack(fill="x")
+        root.mainloop()
+
     if "--record" in sys.argv:
-        print("Recording started, press pen to draw...")
-        create_message_window()
-        message_loop()
+        record()
     elif "--replay" in sys.argv:
-        print("Replaying recording.json...")
         replay()
+    else:
+        run_gui()
+
     if comtypes:
         comtypes.CoUninitialize()
 

--- a/record_pen.py
+++ b/record_pen.py
@@ -16,6 +16,10 @@ import threading
 import tkinter as tk
 from ctypes import wintypes
 
+# Windows type aliases for systems that lack these in ctypes.wintypes
+UINT32 = getattr(wintypes, "UINT32", ctypes.c_uint32)
+INT32 = getattr(wintypes, "INT32", ctypes.c_int32)
+
 
 def is_admin() -> bool:
     """Return True if the script is running with administrator privileges."""
@@ -98,8 +102,8 @@ class POINT(ctypes.Structure):
 class POINTER_INFO(ctypes.Structure):
     _fields_ = [
         ("pointerType", wintypes.DWORD),
-        ("pointerId", wintypes.UINT32),
-        ("frameId", wintypes.UINT32),
+        ("pointerId", UINT32),
+        ("frameId", UINT32),
         ("pointerFlags", wintypes.DWORD),
         ("sourceDevice", wintypes.HANDLE),
         ("hwndTarget", wintypes.HWND),
@@ -108,8 +112,8 @@ class POINTER_INFO(ctypes.Structure):
         ("ptPixelLocationRaw", POINT),
         ("ptHimetricLocationRaw", POINT),
         ("dwTime", wintypes.DWORD),
-        ("historyCount", wintypes.UINT32),
-        ("inputData", wintypes.INT32),
+        ("historyCount", UINT32),
+        ("inputData", INT32),
         ("dwKeyStates", wintypes.DWORD),
         ("PerformanceCount", wintypes.ULONGLONG),
         ("ButtonChangeType", wintypes.DWORD),
@@ -120,10 +124,10 @@ class POINTER_PEN_INFO(ctypes.Structure):
         ("pointerInfo", POINTER_INFO),
         ("penFlags", wintypes.DWORD),
         ("penMask", wintypes.DWORD),
-        ("pressure", wintypes.UINT32),
-        ("rotation", wintypes.UINT32),
-        ("tiltX", wintypes.INT32),
-        ("tiltY", wintypes.INT32),
+        ("pressure", UINT32),
+        ("rotation", UINT32),
+        ("tiltX", INT32),
+        ("tiltY", INT32),
     ]
 
 
@@ -143,9 +147,9 @@ class POINTER_TYPE_INFO(ctypes.Structure):
 GetPointerFramePenInfoHistory = user32.GetPointerFramePenInfoHistory
 GetPointerFramePenInfoHistory.restype = wintypes.BOOL
 GetPointerFramePenInfoHistory.argtypes = [
-    wintypes.UINT32,
-    ctypes.POINTER(ctypes.c_uint32),
-    ctypes.POINTER(ctypes.c_uint32),
+    UINT32,
+    ctypes.POINTER(UINT32),
+    ctypes.POINTER(UINT32),
     ctypes.POINTER(POINTER_PEN_INFO),
 ]
 
@@ -154,7 +158,7 @@ InjectSyntheticPointerInput.restype = wintypes.BOOL
 InjectSyntheticPointerInput.argtypes = [
     wintypes.HANDLE,
     ctypes.POINTER(POINTER_TYPE_INFO),
-    wintypes.UINT32,
+    UINT32,
 ]
 
 # Additional Win32 APIs for injecting pointers without WinRT
@@ -179,7 +183,7 @@ records = []
 def wnd_proc(hwnd, msg, wparam, lparam):
     if msg in (WM_POINTERDOWN, WM_POINTERUPDATE, WM_POINTERUP):
         pointer_id = wparam & 0xFFFF
-        count = ctypes.c_uint32()
+        count = UINT32()
         # Query how many coalesced samples are available
         GetPointerFramePenInfoHistory(pointer_id, None, ctypes.byref(count), None)
         arr_type = POINTER_PEN_INFO * count.value

--- a/record_pen.py
+++ b/record_pen.py
@@ -8,11 +8,52 @@ required.
 
 import ctypes
 import json
+import os
+import subprocess
 import sys
 import time
 import threading
 import tkinter as tk
 from ctypes import wintypes
+
+
+def is_admin() -> bool:
+    """Return True if the script is running with administrator privileges."""
+    if os.name != "nt":
+        return True
+    try:
+        return bool(ctypes.windll.shell32.IsUserAnAdmin())
+    except Exception:
+        return False
+
+
+def relaunch_as_admin():
+    """Relaunch the current script with elevated rights."""
+    if os.name != "nt" or is_admin():
+        return False
+    params = " ".join(f'"{a}"' for a in sys.argv)
+    ctypes.windll.shell32.ShellExecuteW(None, "runas", sys.executable, params, None, 1)
+    sys.exit(0)
+
+
+def ensure_dependencies():
+    """Install required Python packages if missing."""
+    missing = []
+    try:
+        import comtypes  # noqa: F401
+    except Exception:
+        missing.append("comtypes")
+
+    if missing and is_admin():
+        subprocess.call([sys.executable, "-m", "pip", "install", *missing])
+
+    # Reload comtypes if it was just installed
+    global comtypes
+    try:
+        import comtypes as _comtypes
+        comtypes = _comtypes
+    except Exception:
+        comtypes = None
 
 try:
     import comtypes
@@ -271,6 +312,11 @@ def replay():
 
 
 def main():
+    # Relaunch with admin rights if necessary
+    relaunch_as_admin()
+
+    ensure_dependencies()
+
     if comtypes:
         comtypes.CoInitialize()
 

--- a/record_pen.py
+++ b/record_pen.py
@@ -1,0 +1,205 @@
+"""Record and replay pen input on Windows using Raw Pointer and Input Injection APIs."""
+
+import ctypes
+import json
+import sys
+import time
+from ctypes import wintypes
+
+try:
+    import comtypes
+except ImportError:
+    comtypes = None
+
+try:
+    from winrt.windows.ui.input.preview.injection import (
+        InputInjector,
+        InjectedInputPenInfo,
+        InjectedInputPointerInfo,
+        InjectedInputPointerOptions,
+        InjectedInputPenButtons,
+    )
+except ImportError:
+    InputInjector = None
+
+user32 = ctypes.WinDLL("user32", use_last_error=True)
+
+# Constants
+WM_POINTERDOWN = 0x0246
+WM_POINTERUPDATE = 0x0247
+WM_POINTERUP = 0x0248
+
+# Structures from Win32 API
+class POINT(ctypes.Structure):
+    _fields_ = [
+        ("x", wintypes.LONG),
+        ("y", wintypes.LONG),
+    ]
+
+class POINTER_INFO(ctypes.Structure):
+    _fields_ = [
+        ("pointerType", wintypes.DWORD),
+        ("pointerId", wintypes.UINT32),
+        ("frameId", wintypes.UINT32),
+        ("pointerFlags", wintypes.DWORD),
+        ("sourceDevice", wintypes.HANDLE),
+        ("hwndTarget", wintypes.HWND),
+        ("ptPixelLocation", POINT),
+        ("ptHimetricLocation", POINT),
+        ("ptPixelLocationRaw", POINT),
+        ("ptHimetricLocationRaw", POINT),
+        ("dwTime", wintypes.DWORD),
+        ("historyCount", wintypes.UINT32),
+        ("inputData", wintypes.INT32),
+        ("dwKeyStates", wintypes.DWORD),
+        ("PerformanceCount", wintypes.ULONGLONG),
+        ("ButtonChangeType", wintypes.DWORD),
+    ]
+
+class POINTER_PEN_INFO(ctypes.Structure):
+    _fields_ = [
+        ("pointerInfo", POINTER_INFO),
+        ("penFlags", wintypes.DWORD),
+        ("penMask", wintypes.DWORD),
+        ("pressure", wintypes.UINT32),
+        ("rotation", wintypes.UINT32),
+        ("tiltX", wintypes.INT32),
+        ("tiltY", wintypes.INT32),
+    ]
+
+# Function prototypes
+GetPointerFramePenInfoHistory = user32.GetPointerFramePenInfoHistory
+GetPointerFramePenInfoHistory.restype = wintypes.BOOL
+GetPointerFramePenInfoHistory.argtypes = [
+    wintypes.UINT32,
+    ctypes.POINTER(ctypes.c_uint32),
+    ctypes.POINTER(ctypes.c_uint32),
+    ctypes.POINTER(POINTER_PEN_INFO),
+]
+
+InjectSyntheticPointerInput = user32.InjectSyntheticPointerInput
+InjectSyntheticPointerInput.restype = wintypes.BOOL
+InjectSyntheticPointerInput.argtypes = [
+    wintypes.HANDLE,
+    ctypes.POINTER(POINTER_PEN_INFO),
+    wintypes.UINT32,
+]
+
+# Message window setup
+WNDPROC = ctypes.WINFUNCTYPE(wintypes.LRESULT, wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM)
+
+records = []
+
+@WNDPROC
+def wnd_proc(hwnd, msg, wparam, lparam):
+    if msg == WM_POINTERUPDATE:
+        pointer_id = wparam & 0xFFFF
+        count = ctypes.c_uint32()
+        GetPointerFramePenInfoHistory(pointer_id, None, ctypes.byref(count), None)
+        arr_type = POINTER_PEN_INFO * count.value
+        infos = arr_type()
+        GetPointerFramePenInfoHistory(pointer_id, None, ctypes.byref(count), infos)
+        for info in infos:
+            pt = info.pointerInfo.ptPixelLocation
+            records.append({
+                "x": pt.x,
+                "y": pt.y,
+                "pressure": info.pressure,
+                "t": time.time(),
+            })
+    elif msg == WM_POINTERUP:
+        with open("recording.json", "w", encoding="utf-8") as f:
+            json.dump(records, f, indent=2)
+        print("Recording saved to recording.json")
+    return user32.DefWindowProcW(hwnd, msg, wparam, lparam)
+
+WNDCLASS = ctypes.Structure
+class WNDCLASS(ctypes.Structure):
+    _fields_ = [
+        ("style", wintypes.UINT),
+        ("lpfnWndProc", WNDPROC),
+        ("cbClsExtra", ctypes.c_int),
+        ("cbWndExtra", ctypes.c_int),
+        ("hInstance", wintypes.HINSTANCE),
+        ("hIcon", wintypes.HICON),
+        ("hCursor", wintypes.HCURSOR),
+        ("hbrBackground", wintypes.HBRUSH),
+        ("lpszMenuName", wintypes.LPCWSTR),
+        ("lpszClassName", wintypes.LPCWSTR),
+    ]
+
+atom = None
+hwnd = None
+
+
+def create_message_window():
+    global atom, hwnd
+    class_name = "PenRecorderWindow"
+    wc = WNDCLASS()
+    wc.lpfnWndProc = wnd_proc
+    wc.lpszClassName = class_name
+    wc.hInstance = user32.GetModuleHandleW(None)
+    atom = user32.RegisterClassW(ctypes.byref(wc))
+    hwnd = user32.CreateWindowExW(
+        0,
+        atom,
+        class_name,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x00000000 | 0x00000080,  # WS_OVERLAPPED, WS_EX_NOACTIVATE
+        0,
+        wc.hInstance,
+        None,
+    )
+
+
+def message_loop():
+    msg = wintypes.MSG()
+    while user32.GetMessageW(ctypes.byref(msg), 0, 0, 0) != 0:
+        user32.TranslateMessage(ctypes.byref(msg))
+        user32.DispatchMessageW(ctypes.byref(msg))
+
+
+def replay():
+    if InputInjector is None:
+        print("WinRT input injection APIs not available")
+        return
+    with open("recording.json", "r", encoding="utf-8") as f:
+        events = json.load(f)
+    injector = InputInjector.try_create()
+    if injector is None:
+        print("Failed to create InputInjector")
+        return
+    prev_t = None
+    for ev in events:
+        if prev_t is not None:
+            time.sleep(max(ev["t"] - prev_t, 0))
+        prev_t = ev["t"]
+        pen = InjectedInputPenInfo()
+        info = InjectedInputPointerInfo()
+        info.pointer_options = InjectedInputPointerOptions.IN_CONTACT | InjectedInputPointerOptions.PEN
+        info.pixel_location = POINT(ev["x"], ev["y"])
+        pen.pointer_info = info
+        pen.pressure = int(ev["pressure"])
+        injector.inject_pen_input([pen])
+
+
+def main():
+    if comtypes:
+        comtypes.CoInitialize()
+    if "--record" in sys.argv:
+        print("Recording started, press pen to draw...")
+        create_message_window()
+        message_loop()
+    elif "--replay" in sys.argv:
+        print("Replaying recording.json...")
+        replay()
+    if comtypes:
+        comtypes.CoUninitialize()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python example `record_pen.py` to capture and replay pen input
- document how to use the script in README

## Testing
- `python3 -m py_compile record_pen.py`


------
https://chatgpt.com/codex/tasks/task_e_68697232f25c832daef6d11ae1e7d478